### PR TITLE
Vendor Snapshot Manifests + GCP Snapshot Setup Script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/customer/snapshot-feature/setup-gcp.sh
+++ b/customer/snapshot-feature/setup-gcp.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+## Script to help set up GCP storage for snapshot functionality
+## Requires: gsutil and for your account project to be linked via command line. 
+## Validated on OSX shell
+
+BUCKET_NAME=replsnap-$(LC_CTYPE=C tr -dc a-z0-9 < /dev/urandom | head -c 16 | xargs)
+## Create the bucket
+gsutil mb -l US gs://$BUCKET_NAME
+## Create the iam account
+gcloud iam service-accounts create "$BUCKET_NAME" --display-name="$BUCKET_NAME"
+## Create the key linked to the IAM account and save
+PROJECT_NAME=$(gcloud config list --format 'value(core.project)' 2>/dev/null)
+IAM_ACCT="${BUCKET_NAME}@${PROJECT_NAME}.iam.gserviceaccount.com"
+gcloud iam service-accounts keys create "./${BUCKET_NAME}.key" --iam-account="$IAM_ACCT"
+
+## Add role to service account. 
+gcloud projects add-iam-policy-binding $PROJECT_NAME \
+  --member serviceAccount:$IAM_ACCT \
+  --role "roles/storage.admin"
+
+## Copy key to Replicated Admin Console: /app/airgapped/snapshots/settings
+pbcopy < "./${BUCKET_NAME}.key" 
+printf "\n\nBUCKET_NAME: $BUCKET_NAME\n\n"
+read -p "Enter bucket name, path, and paste key to Replicated Admin Console /app/airgapped/snapshots/settings"
+

--- a/vendor/snapshot-feature/README.md
+++ b/vendor/snapshot-feature/README.md
@@ -1,0 +1,8 @@
+# Application Manifests for Snapshot Feature
+
+# Example how-to
+1. Create a new KOTS application
+2. Copy "kubernetes.yaml" from /kubernetes-installer to the "Kubernetes Installers" in Vendor and promote to channels. (Or simply add `velero: version: latest` to your default YAML)
+3. Create a new release with default manifests. 
+4. Drag and drop contents from this /manifests folder. 
+5. Promote your release. Admin Console setup may need to happen separately (e.g., customer using GCP to backup)

--- a/vendor/snapshot-feature/kubernetes-installer/kubernetes.yaml
+++ b/vendor/snapshot-feature/kubernetes-installer/kubernetes.yaml
@@ -1,0 +1,23 @@
+apiversion: kurl.sh/v1beta1
+kind: Installer
+metadata:
+  name: ""
+spec:
+  contour:
+    version: latest
+  docker:
+    version: latest
+  kotsadm:
+    version: latest
+  kubernetes:
+    version: latest
+  prometheus:
+    version: latest
+  registry:
+    version: latest
+  rook:
+    version: latest
+  weave:
+    version: latest
+  velero:
+    version: latest

--- a/vendor/snapshot-feature/manifests/backup.yaml
+++ b/vendor/snapshot-feature/manifests/backup.yaml
@@ -1,0 +1,27 @@
+apiVersion: velero.io/v1
+kind: Backup
+metadata:
+  name: backup
+spec:
+  includedNamespaces:
+  - test
+  hooks:
+    resources:
+    - name: echo-hook
+      includedNamespaces:
+      - '*'
+      includedResources:
+      - 'pods'
+      labelSelector:
+        matchLabels:
+          app: example
+          component: nginx
+      pre:
+      - exec:
+          command: ["/bin/bash", "-c", "echo hello"]
+      - exec:
+          command: ["/bin/bash", "-c", "echo $(date) > /scratch/timestamp"]
+      - exec:
+          command: ["/bin/bash", "-c", "head -c 1G </dev/urandom >/scratch/data"]
+          timeout: 3m
+          onError: Continue

--- a/vendor/snapshot-feature/manifests/nginx.yaml
+++ b/vendor/snapshot-feature/manifests/nginx.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: example-nginx
+  labels:
+    app: example
+    component: nginx
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: example
+      component: nginx
+  template:
+    metadata:
+      annotations:
+        backup.velero.io/backup-volumes: scratch
+      labels:
+        app: example
+        component: nginx
+    spec:
+      volumes:
+      - name: scratch
+        emptyDir: {}
+      containers:
+        - name: nginx
+          image: nginx
+          envFrom:
+          - configMapRef:
+              name: example-config
+          resources:
+            limits:
+              memory: '256Mi'
+              cpu: '500m'
+          volumeMounts:
+          - name: scratch
+            mountPath: /scratch


### PR DESCRIPTION
1. Copied over @areed's example manifests (modified namespace to `default`).  With instructions to support. 
2. Created a mostly-automated script to create a bucket + service account in IAM for hosting snapshots in GCP. 

